### PR TITLE
Compatibility with ESP-IDF version>5.0.2

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -8,7 +8,7 @@
 
 
 #ifdef ESP32
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 2)
+#if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(5, 0, 2)
     #define RSA_KEY_LENGTH 1024
 #else
     #define RSA_KEY_LENGTH 512

--- a/src/config.h
+++ b/src/config.h
@@ -1,11 +1,18 @@
 #ifndef CONFIG_H_
 #define CONFIG_H_
 
+#include "esp_idf_version.h"
+
 #define SCTP_MTU (1200)
 #define CONFIG_MTU (1300)
 
+
 #ifdef ESP32
-#define RSA_KEY_LENGTH 512
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 2)
+    #define RSA_KEY_LENGTH 1024
+#else
+    #define RSA_KEY_LENGTH 512
+#endif
 #define VIDEO_RB_DATA_LENGTH (CONFIG_MTU * 64)
 #define AUDIO_RB_DATA_LENGTH (CONFIG_MTU * 64)
 #define DATA_RB_DATA_LENGTH (SCTP_MTU * 128)

--- a/src/dtls_srtp.c
+++ b/src/dtls_srtp.c
@@ -87,8 +87,12 @@ static int dtls_srtp_selfsign_cert(DtlsSrtp *dtls_srtp) {
   int ret;
 
   mbedtls_x509write_cert crt;
-
-  mbedtls_mpi serial;
+  
+  #if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(5, 0, 2)
+    char *serial = "peer";
+  #else
+    mbedtls_mpi serial;
+  #endif
 
   unsigned char *cert_buf = (unsigned char *) malloc(RSA_KEY_LENGTH * 2);
 
@@ -116,11 +120,13 @@ static int dtls_srtp_selfsign_cert(DtlsSrtp *dtls_srtp) {
 
   mbedtls_x509write_crt_set_issuer_name(&crt, "CN=dtls_srtp");
 
-  mbedtls_mpi_init(&serial);
-
-  mbedtls_mpi_fill_random(&serial, 16, mbedtls_ctr_drbg_random, &dtls_srtp->ctr_drbg);
-
-  mbedtls_x509write_crt_set_serial(&crt, &serial);
+  #if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(5, 0, 2)
+    mbedtls_x509write_crt_set_serial_raw(&crt, (unsigned char *) serial, strlen(serial));
+  #else
+    mbedtls_mpi_init(&serial);
+    mbedtls_mpi_fill_random(&serial, 16, mbedtls_ctr_drbg_random, &dtls_srtp->ctr_drbg);
+    mbedtls_x509write_crt_set_serial(&crt, &serial);
+  #endif
 
   mbedtls_x509write_crt_set_validity(&crt, "20180101000000", "20280101000000");
 
@@ -134,8 +140,11 @@ static int dtls_srtp_selfsign_cert(DtlsSrtp *dtls_srtp) {
   mbedtls_x509_crt_parse(&dtls_srtp->cert, cert_buf, 2*RSA_KEY_LENGTH);
 
   mbedtls_x509write_crt_free(&crt);
-
-  mbedtls_mpi_free(&serial);
+  
+  #if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(5, 0, 2)
+  #else
+    mbedtls_mpi_free(&serial);
+  #endif
 
   free(cert_buf);
 


### PR DESCRIPTION
In ESP-IDF versions > 5.0.2, a newer mbedtls version is used, which means:

1. RSA_KEY_LENGTH of less than 1024 bit is no longer accepted. (Although this could be altered from mbedtls/config.h).
2. mbedtls_x509write_crt_set_serial is deprecated in favor of mbedtls_x509write_crt_set_serial_raw.

Therefore this pull request is:

1. Increasing the RSA_KEY_LENGTH to 1024 when ESP-IDF versions > 5.0.2.
2. Using mbedtls_x509write_crt_set_serial_raw instead of mbedtls_x509write_crt_set_serial when ESP-IDF versions > 5.0.2.


