### PR TITLE
build: include missing headers to build with musl libc

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 
 #include <pthread.h>
 #include "socket.h"
@@ -266,7 +267,7 @@ void agent_gather_candidate(Agent *agent, const char *urls, const char *username
       if (ports_resolve_addr(hostname, &resolved_addr) != 0) {
         continue;
       }
- 
+
       addr_set_port(&resolved_addr, port);
       addr_to_string(&resolved_addr, addr_string, sizeof(addr_string));
       LOGI("stun/turn server %s:%d", addr_string, port);

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 #include <netinet/in.h>
 #include <inttypes.h>
 #include "utils.h"
@@ -70,7 +71,7 @@ static int mdns_parse_answer(uint8_t *buf, int size, Address *addr) {
     return -1;
   }
 
-  memcpy(&addr->sin.sin_addr, answer->data, 4); 
+  memcpy(&addr->sin.sin_addr, answer->data, 4);
   return 0;
 }
 


### PR DESCRIPTION
`sys/select.h` is needed to define `fd_set`.