### PR TITLE
build: Header paths differ on MacOS Sonoma

### DIFF
--- a/src/rtcp.h
+++ b/src/rtcp.h
@@ -2,7 +2,12 @@
 #define RTCP_H_
 
 #include <stdint.h>
+#ifdef __APPLE__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
+
 
 typedef enum RtcpType {
 

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -2,7 +2,12 @@
 #define RTP_H_
 
 #include <stdint.h>
+#ifdef __APPLE__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
+
 
 #include "peer_connection.h"
 #include "config.h"


### PR DESCRIPTION
Hello!

Thank you so much for adding ExternalProject_Add's for the third party dependencies in this lib. I was maintaining my own fork for a while which added those, along with this small header variant that fixes compilation for MacOS.