### PR TITLE
build: allow configuring static/shared libpeer builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(peer)
 
 option(ENABLE_TESTS "Enable tests" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 include(ExternalProject)
 include(third_party/coreHTTP/httpFilePaths.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ file(GLOB SRCS "*.c")
 
 file(GLOB HEADERS "peer.h" "peer_connection.h" "peer_signaling.h")
 
-add_library(peer SHARED
+add_library(peer
   ${SRCS}
   ${HTTP_SOURCES}
   ${MQTT_SOURCES}


### PR DESCRIPTION
Building with musl for RISC-V prefers static libpeer.