### PR TITLE
signaling: configurable buffer sizes via macros

### DIFF
--- a/src/agent.h
+++ b/src/agent.h
@@ -16,9 +16,17 @@
 #include "ice.h"
 #include "base64.h"
 
+#ifndef AGENT_MAX_DESCRIPTION
 #define AGENT_MAX_DESCRIPTION 40960
+#endif
+
+#ifndef AGENT_MAX_CANDIDATES
 #define AGENT_MAX_CANDIDATES 10
+#endif
+
+#ifndef AGENT_MAX_CANDIDATE_PAIRS
 #define AGENT_MAX_CANDIDATE_PAIRS 100
+#endif
 
 typedef enum AgentState {
 

--- a/src/peer_signaling.c
+++ b/src/peer_signaling.c
@@ -16,7 +16,11 @@
 
 #define KEEP_ALIVE_TIMEOUT_SECONDS 60
 #define CONNACK_RECV_TIMEOUT_MS 1000
+
+#ifndef BUF_SIZE
 #define BUF_SIZE 4096
+#endif
+
 #define TOPIC_SIZE 128
 
 #define HOST_LEN 64


### PR DESCRIPTION
Werift can return SDPs of over 4096 in size and more than 10 candidates. This change makes these buffers configurable at build time.