### PR TITLE
Fix missing include for `time`

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -3,6 +3,7 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <time.h>
 
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
Add <time.h> to utils.c to fix compile error on Linux