### PR TITLE
Add 'DISABLE_PEER_SIGNALING'

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -25,4 +25,7 @@
 // #define LOG_LEVEL LEVEL_DEBUG
 #define LOG_REDIRECT 0
 
+// Disable MQTT and HTTP signaling
+// #define DISABLE_PEER_SIGNALING 1
+
 #endif  // CONFIG_H_

--- a/src/peer_signaling.c
+++ b/src/peer_signaling.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_PEER_SIGNALING
 #include <assert.h>
 #include <cJSON.h>
 #include <signal.h>
@@ -526,3 +527,4 @@ void peer_signaling_set_config(ServiceConfiguration* service_config) {
   g_ps.pc = service_config->pc;
   peer_connection_onicecandidate(g_ps.pc, peer_signaling_onicecandidate);
 }
+#endif  // DISABLE_PEER_SIGNALING

--- a/src/peer_signaling.h
+++ b/src/peer_signaling.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+#ifndef DISABLE_PEER_SIGNALING
+
 typedef struct ServiceConfiguration {
   const char* mqtt_url;
   int mqtt_port;
@@ -45,5 +47,7 @@ int peer_signaling_loop();
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // DISABLE_PEER_SIGNALING
 
 #endif  // PEER_SIGNALING_H_

--- a/src/ssl_transport.c
+++ b/src/ssl_transport.c
@@ -1,3 +1,4 @@
+#ifndef DISABLE_PEER_SIGNALING
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -122,3 +123,4 @@ int ssl_transport_send(NetworkContext_t* net_ctx, const void* buf, size_t len) {
 
   return ret;
 }
+#endif  // DISABLE_PEER_SIGNALING

--- a/src/ssl_transport.h
+++ b/src/ssl_transport.h
@@ -1,6 +1,8 @@
 #ifndef SSL_TRANSPORT_H_
 #define SSL_TRANSPORT_H_
 
+#ifndef DISABLE_PEER_SIGNALING
+
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/ssl.h>
@@ -29,4 +31,5 @@ int ssl_transport_recv(NetworkContext_t* net_ctx, void* buf, size_t len);
 
 int ssl_transport_send(NetworkContext_t* net_ctx, const void* buf, size_t len);
 
+#endif  // DISABLE_PEER_SIGNALING
 #endif  // SSL_TRANSPORT_H_


### PR DESCRIPTION
Allows library to be used without MQTT/HTTP dependencies