### PR TITLE
agent_deinit usage is needed at TURN mode.

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -58,6 +58,11 @@ void agent_destroy(Agent* agent) {
 #endif
 }
 
+void agent_deinit(Agent* agent) {
+  agent_destroy(agent);
+  agent_create(agent);
+}
+
 static int agent_socket_recv(Agent* agent, Address* addr, uint8_t* buf, int len) {
   int ret = -1;
   int i = 0;

--- a/src/agent.h
+++ b/src/agent.h
@@ -96,4 +96,6 @@ int agent_create(Agent* agent);
 
 void agent_destroy(Agent* agent);
 
+void agent_deinit(Agent* agent);
+
 #endif  // AGENT_H_

--- a/src/peer_connection.c
+++ b/src/peer_connection.c
@@ -261,14 +261,14 @@ static void peer_connection_state_new(PeerConnection* pc, DtlsSrtpRole role) {
 
   memset(pc->temp_buf, 0, sizeof(pc->temp_buf));
 
+  agent_deinit(&pc->agent);
+
   dtls_srtp_reset_session(&pc->dtls_srtp);
   dtls_srtp_init(&pc->dtls_srtp, role, pc);
   pc->dtls_srtp.udp_recv = peer_connection_dtls_srtp_recv;
   pc->dtls_srtp.udp_send = peer_connection_dtls_srtp_send;
 
   pc->sctp.connected = 0;
-
-  agent_clear_candidates(&pc->agent);
 
   agent_gather_candidate(&pc->agent, NULL, NULL, NULL);  // host address
   for (int i = 0; i < sizeof(pc->config.ice_servers) / sizeof(pc->config.ice_servers[0]); ++i) {


### PR DESCRIPTION
For esample: libpeer was connected with Turn, but web gets a refresh action, then libpeer needs to do a new TURN binding again(function peer_connection_state_new). 

If no using agent_deinit, TURN will return some kind of 'new binding fail error' for the Previous-binding connection was not cut off.

So the second call of peer_connection_state_new would always failed at agent_create_turn_addr. 

Use agent_deinit every time at peer_connection_state_new would fix that.