### PR TITLE
Set MBEDTLS_SSL_CERT_REQ_CA_LIST_DISABLED

### DIFF
--- a/src/dtls_srtp.c
+++ b/src/dtls_srtp.c
@@ -181,6 +181,8 @@ int dtls_srtp_init(DtlsSrtp* dtls_srtp, DtlsSrtpRole role, void* user_data) {
 
   mbedtls_ssl_conf_srtp_mki_value_supported(&dtls_srtp->conf, MBEDTLS_SSL_DTLS_SRTP_MKI_UNSUPPORTED);
 
+  mbedtls_ssl_conf_cert_req_ca_list(&dtls_srtp->conf, MBEDTLS_SSL_CERT_REQ_CA_LIST_DISABLED);
+
   mbedtls_ssl_setup(&dtls_srtp->ssl, &dtls_srtp->conf);
 
   return 0;


### PR DESCRIPTION
We are using self-signed certificates. If the remote doesn't generate with "dtls_srtp" as the CA negotation will fail with this set.