### PR TITLE
fix compile error for DISABLE_PEER_SIGNALING

### DIFF
--- a/src/peer_signaling.h
+++ b/src/peer_signaling.h
@@ -44,10 +44,10 @@ void peer_signaling_leave_channel();
 
 int peer_signaling_loop();
 
+#endif  // DISABLE_PEER_SIGNALING
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif  // DISABLE_PEER_SIGNALING
 
 #endif  // PEER_SIGNALING_H_


### PR DESCRIPTION
if define DISABLE_PEER_SIGNALING, the file will ends with lossing a brackets.