### PR TITLE
fix memory leak

### DIFF
--- a/examples/generic/main.c
+++ b/examples/generic/main.c
@@ -24,7 +24,7 @@ static void onclose(void* user_data) {
 }
 
 static void onmessage(char* msg, size_t len, void* user_data, uint16_t sid) {
-  printf("on message: %d %s", sid, msg);
+  printf("on message: %d %.*s", sid, (int)len, msg);
 
   if (strncmp(msg, "ping", 4) == 0) {
     printf(", send pong\n");

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -27,6 +27,7 @@ void buffer_free(Buffer* rb) {
   if (rb) {
     free(rb->data);
     rb->data = NULL;
+    free(rb);
     rb = NULL;
   }
 }

--- a/src/peer_connection.c
+++ b/src/peer_connection.c
@@ -208,6 +208,8 @@ PeerConnection* peer_connection_create(PeerConfiguration* config) {
 
 void peer_connection_destroy(PeerConnection* pc) {
   if (pc) {
+    sctp_destroy_socket(&pc->sctp);
+    dtls_srtp_deinit(&pc->dtls_srtp);
     agent_destroy(&pc->agent);
     buffer_free(pc->data_rb);
     buffer_free(pc->audio_rb);

--- a/src/sctp.h
+++ b/src/sctp.h
@@ -161,6 +161,8 @@ void sctp_destroy(Sctp* sctp);
 
 int sctp_create_socket(Sctp* sctp, DtlsSrtp* dtls_srtp);
 
+void sctp_destroy_socket(Sctp* sctp);
+
 int sctp_is_connected(Sctp* sctp);
 
 void sctp_incoming_data(Sctp* sctp, char* buf, size_t len);

--- a/src/stun.c
+++ b/src/stun.c
@@ -238,7 +238,8 @@ int stun_msg_write_attr(StunMessage* msg, StunAttrType type, uint16_t length, ch
 
   stun_attr->type = htons(type);
   stun_attr->length = htons(length);
-  memcpy(stun_attr->value, value, length);
+  if (value)
+    memcpy(stun_attr->value, value, length);
 
   length = 4 * ((length + 3) / 4);
   header->length = htons(ntohs(header->length) + sizeof(StunAttribute) + length);


### PR DESCRIPTION
After turning on the ADDRESS_SANITIZER switch, I noticed that there was some memory leak.
PeerConnection: dtls_srtp and sctp were not released.
                sctp_incoming_data_cb did't free the memory that usrsctp allocates
Buffer: itself was not released.