### PR TITLE
Fixed DTLS SRTP keys parsing.

### DIFF
--- a/src/dtls_srtp.c
+++ b/src/dtls_srtp.c
@@ -270,6 +270,11 @@ static int dtls_srtp_key_derivation(DtlsSrtp* dtls_srtp, const unsigned char* ma
   printf("\n");
 #endif
 
+  const uint8_t* client_key = key_material;
+  const uint8_t* server_key = client_key + SRTP_MASTER_KEY_LENGTH;
+  const uint8_t* client_salt = server_key + SRTP_MASTER_KEY_LENGTH;
+  const uint8_t* server_salt = client_salt + SRTP_MASTER_SALT_LENGTH;
+
   // derive inbounds keys
 
   memset(&dtls_srtp->remote_policy, 0, sizeof(dtls_srtp->remote_policy));
@@ -277,8 +282,8 @@ static int dtls_srtp_key_derivation(DtlsSrtp* dtls_srtp, const unsigned char* ma
   srtp_crypto_policy_set_rtp_default(&dtls_srtp->remote_policy.rtp);
   srtp_crypto_policy_set_rtcp_default(&dtls_srtp->remote_policy.rtcp);
 
-  memcpy(dtls_srtp->remote_policy_key, key_material, SRTP_MASTER_KEY_LENGTH);
-  memcpy(dtls_srtp->remote_policy_key + SRTP_MASTER_KEY_LENGTH, key_material + SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_KEY_LENGTH, SRTP_MASTER_SALT_LENGTH);
+  memcpy(dtls_srtp->remote_policy_key, server_key, SRTP_MASTER_KEY_LENGTH);
+  memcpy(dtls_srtp->remote_policy_key + SRTP_MASTER_KEY_LENGTH, server_salt, SRTP_MASTER_SALT_LENGTH);
 
   dtls_srtp->remote_policy.ssrc.type = ssrc_any_inbound;
   dtls_srtp->remote_policy.key = dtls_srtp->remote_policy_key;
@@ -297,8 +302,8 @@ static int dtls_srtp_key_derivation(DtlsSrtp* dtls_srtp, const unsigned char* ma
   srtp_crypto_policy_set_rtp_default(&dtls_srtp->local_policy.rtp);
   srtp_crypto_policy_set_rtcp_default(&dtls_srtp->local_policy.rtcp);
 
-  memcpy(dtls_srtp->local_policy_key, key_material + SRTP_MASTER_KEY_LENGTH, SRTP_MASTER_KEY_LENGTH);
-  memcpy(dtls_srtp->local_policy_key + SRTP_MASTER_KEY_LENGTH, key_material + SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH, SRTP_MASTER_SALT_LENGTH);
+  memcpy(dtls_srtp->local_policy_key, client_key, SRTP_MASTER_KEY_LENGTH);
+  memcpy(dtls_srtp->local_policy_key + SRTP_MASTER_KEY_LENGTH, client_salt, SRTP_MASTER_SALT_LENGTH);
 
   dtls_srtp->local_policy.ssrc.type = ssrc_any_outbound;
   dtls_srtp->local_policy.key = dtls_srtp->local_policy_key;


### PR DESCRIPTION
According to RFC5764 section 4.2, keys are assigned as shown below: client_write_SRTP_master_key[SRTPSecurityParams.master_key_len]; server_write_SRTP_master_key[SRTPSecurityParams.master_key_len]; client_write_SRTP_master_salt[SRTPSecurityParams.master_salt_len]; server_write_SRTP_master_salt[SRTPSecurityParams.master_salt_len];