### PR TITLE
The c line in the media description should come after the m line.

### DIFF
--- a/src/sdp.c
+++ b/src/sdp.c
@@ -27,6 +27,7 @@ void sdp_reset(Sdp* sdp) {
 
 void sdp_append_h264(Sdp* sdp) {
   sdp_append(sdp, "m=video 9 UDP/TLS/RTP/SAVPF 96 102");
+  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=rtcp-fb:102 nack");
   sdp_append(sdp, "a=rtcp-fb:102 nack pli");
   sdp_append(sdp, "a=fmtp:96 profile-level-id=42e01f;level-asymmetry-allowed=1");
@@ -36,45 +37,44 @@ void sdp_append_h264(Sdp* sdp) {
   sdp_append(sdp, "a=ssrc:1 cname:webrtc-h264");
   sdp_append(sdp, "a=sendrecv");
   sdp_append(sdp, "a=mid:video");
-  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=rtcp-mux");
 }
 
 void sdp_append_pcma(Sdp* sdp) {
   sdp_append(sdp, "m=audio 9 UDP/TLS/RTP/SAVP 8");
+  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=rtpmap:8 PCMA/8000");
   sdp_append(sdp, "a=ssrc:4 cname:webrtc-pcma");
   sdp_append(sdp, "a=sendrecv");
   sdp_append(sdp, "a=mid:audio");
-  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=rtcp-mux");
 }
 
 void sdp_append_pcmu(Sdp* sdp) {
   sdp_append(sdp, "m=audio 9 UDP/TLS/RTP/SAVP 0");
+  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=rtpmap:0 PCMU/8000");
   sdp_append(sdp, "a=ssrc:5 cname:webrtc-pcmu");
   sdp_append(sdp, "a=sendrecv");
   sdp_append(sdp, "a=mid:audio");
-  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=rtcp-mux");
 }
 
 void sdp_append_opus(Sdp* sdp) {
   sdp_append(sdp, "m=audio 9 UDP/TLS/RTP/SAVP 111");
+  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=rtpmap:111 opus/48000/2");
   sdp_append(sdp, "a=ssrc:6 cname:webrtc-opus");
   sdp_append(sdp, "a=sendrecv");
   sdp_append(sdp, "a=mid:audio");
-  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=rtcp-mux");
 }
 
 void sdp_append_datachannel(Sdp* sdp) {
   sdp_append(sdp, "m=application 50712 UDP/DTLS/SCTP webrtc-datachannel");
+  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=mid:datachannel");
   sdp_append(sdp, "a=sctp-port:5000");
-  sdp_append(sdp, "c=IN IP4 0.0.0.0");
   sdp_append(sdp, "a=max-message-size:262144");
 }
 


### PR DESCRIPTION
According to RFC 4566 section 5:
      Media description, if present
         m=  (media name and transport address)
         i=* (media title)
         c=* (connection information -- optional if included at
              session level)
         b=* (zero or more bandwidth information lines)
         k=* (encryption key)
         a=* (zero or more media attribute lines)

TEST: can be parsed with jsdp