### PR TITLE
In LEVEL_DEBUG mode, stun.c uses <%08" PRIu32 "> to print logs, but the <inttypes.h> header is missing.

### DIFF
--- a/src/stun.c
+++ b/src/stun.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Hi, author. In LEVEL_DEBUG mode, stun.c uses <%08" PRIu32 "> to print logs, but the <inttypes.h> header is missing. It may be necessary to add <inttypes.h> to stun.c.