### PR TITLE
fix_sdp_ice

### DIFF
--- a/src/peer_connection.c
+++ b/src/peer_connection.c
@@ -454,7 +454,7 @@ static const char* peer_connection_create_sdp(PeerConnection* pc, SdpType sdp_ty
     }
   }
   agent_get_local_description(&pc->agent, description, sizeof(pc->temp_buf));
-  
+
   memset(pc->sdp, 0, sizeof(pc->sdp));
   // TODO: check if we have video or audio codecs
   sdp_create(pc->sdp,


### PR DESCRIPTION
https://github.com/sepfy/libpeer/blob/fix_sdp_ice/src/peer_connection.c#L494
```
sdp_append(pc->sdp, description);
```
该调用未针对音视频部分追加 ICE 信息，仅处理datachannel，导致连接建立失败

