### PR TITLE
fix: bad udp payload on esp32

### DIFF
--- a/src/stun.c
+++ b/src/stun.c
@@ -51,9 +51,9 @@ void stun_msg_create(StunMessage* msg, uint16_t type) {
   header->type = htons(type);
   header->length = 0;
   header->magic_cookie = htonl(MAGIC_COOKIE);
-  header->transaction_id[0] = htonl(0x12345678);
-  header->transaction_id[1] = htonl(0x90abcdef);
-  header->transaction_id[2] = htonl(0x12345678);
+  header->transaction_id[0] = htonl(CRC32_TABLE[1]);
+  header->transaction_id[1] = htonl(CRC32_TABLE[2]);
+  header->transaction_id[2] = htonl(CRC32_TABLE[3]);
   msg->size = sizeof(StunHeader);
 }
 


### PR DESCRIPTION
Very very odd issue I found using `libpeer` with idf version 5.4.1.

The stun header has a particular pattern on the first 12 bytes that cause the udp client to not send any data. I am running on an esp32s3 wrroom.

It is causing the ICE negotiation to fail after an offer / answer exchange between two peers.

This was the original stun request i was trying to send. It will fail after 11 bytes being sent.

```
00 01 00 54 21 12 A4 42 12 34 56 78 90 AB CD EF 
12 34 56 78 00 06 00 15 7A 4D 51 54 77 63 56 72 
45 43 42 4A 49 72 68 65 3A 64 52 56 43 00 00 00 
00 24 00 04 FE 4E E5 FD 00 25 00 00 80 2A 00 08 
00 00 00 00 00 00 00 00 00 08 00 14 7F 8F FD 4B 
E4 55 C6 9A E5 8A D2 29 98 6D 62 C8 17 19 23 54 
80 28 00 04 31 9A 96 0E
```

How to recreate:

```
#include <esp_log.h>
#include <nvs_flash.h>
#include <sys/socket.h>

void app_main(void) {
  esp_err_t ret = nvs_flash_init();
  if (ret == ESP_ERR_NVS_NO_FREE_PAGES ||
      ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
    ESP_ERROR_CHECK(nvs_flash_erase());
    ret = nvs_flash_init();
  }
  ESP_ERROR_CHECK(ret);

  // Block until connection
  wifi();

  struct sockaddr_in dest_addr;

  dest_addr.sin_addr.s_addr = inet_addr("192.168.1.250");  // enter proper ip
  dest_addr.sin_family = AF_INET;
  dest_addr.sin_port = htons(3535);

  int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
  if (sock < 0) {
    ESP_LOGE(LOG_TAG, "Unable to create socket: errno %d", errno);
    vTaskDelete(NULL);
    return;
  }

  uint8_t data[] = {0x00, 0x01, 0x00, 0x54, 0x21, 0x12, 0xA4, 0x42,
                    0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF};

  for (int i = 1; i <= sizeof(data); i++) {
    int n = sendto(sock, data, i, 0, (struct sockaddr *)&dest_addr,
                   sizeof(dest_addr));

    ESP_LOGI(LOG_TAG, "sent %d bytes", n);
    vTaskDelay(pdMS_TO_TICKS(1000));
  }

  ESP_LOGI(LOG_TAG, "finished.");

  while (1) {
    vTaskDelay(pdMS_TO_TICKS(1000));
  }
}
```
and run wireshark to capture packets

```
tcpdump -n udp port 3535 -w out.pcap
```

<img width="995" height="261" alt="Screenshot from 2025-07-29 23-15-18" src="https://github.com/user-attachments/assets/fb98b351-aeb5-4bd6-9e25-dc6903653385" />
<img width="709" height="340" alt="Screenshot from 2025-07-29 23-15-08" src="https://github.com/user-attachments/assets/00bacdc5-b935-45bd-ac11-171b6cc0a18f" />

