### PR TITLE
Suppress unknown attribute warning for SOFTWARE (0x8022)

### DIFF
--- a/src/stun.c
+++ b/src/stun.c
@@ -210,6 +210,7 @@ void stun_parse_msg_buf(StunMessage* msg) {
       case STUN_ATTR_TYPE_ICE_CONTROLLED:
       case STUN_ATTR_TYPE_ICE_CONTROLLING:
       case STUN_ATTR_TYPE_NETWORK_COST:
+      case STUN_ATTR_TYPE_SOFTWARE:
         // Do nothing
         break;
       default:


### PR DESCRIPTION
- Add `STUN_ATTR_TYPE_SOFTWARE` to the list of ignored STUN attributes
- Prevents noisy "Unknown Attribute Type: 0x8022" log messages