### PR TITLE
Allow to configure frame rate and audio duration

### DIFF
--- a/src/peer_connection.c
+++ b/src/peer_connection.c
@@ -165,6 +165,34 @@ PeerConnection* peer_connection_create(PeerConfiguration* config) {
   memset(&pc->sctp, 0, sizeof(pc->sctp));
 
   if (pc->config.audio_codec) {
+    
+	switch(pc->config.audio_codec)
+	{
+		case CODEC_PCMA:
+		case CODEC_PCMU:
+			if (pc->config.audio_duration)
+			{
+				pc->artp_encoder.timestamp_increment = pc->config.audio_duration * 8000 / 1000;
+			}
+			else
+			{
+				pc->artp_encoder.timestamp_increment = CONFIG_AUDIO_DURATION * 8000 / 1000;
+			}
+			break;
+		case CODEC_OPUS:
+			if (pc->config.audio_duration)
+			{
+				pc->artp_encoder.timestamp_increment = pc->config.audio_duration * 48000 / 1000;
+			}
+			else
+			{
+				pc->artp_encoder.timestamp_increment = CONFIG_AUDIO_DURATION * 48000 / 1000;
+			}
+			break;
+		default:
+		  break;
+	}
+
     rtp_encoder_init(&pc->artp_encoder, pc->config.audio_codec,
                      peer_connection_outgoing_rtp_packet, (void*)pc);
 
@@ -173,6 +201,11 @@ PeerConnection* peer_connection_create(PeerConfiguration* config) {
   }
 
   if (pc->config.video_codec) {
+    if (pc->config.video_frame_rate)
+    {
+      pc->vrtp_encoder.timestamp_increment = 90000 / (pc->config.video_frame_rate);
+    }
+
     rtp_encoder_init(&pc->vrtp_encoder, pc->config.video_codec,
                      peer_connection_outgoing_rtp_packet, (void*)pc);
 

--- a/src/peer_connection.h
+++ b/src/peer_connection.h
@@ -75,6 +75,8 @@ typedef struct PeerConfiguration {
   MediaCodec audio_codec;
   MediaCodec video_codec;
   DataChannelType datachannel;
+  uint32_t video_frame_rate;
+  uint16_t audio_duration;
 
   void (*onaudiotrack)(uint8_t* data, size_t size, void* userdata);
   void (*onvideotrack)(uint8_t* data, size_t size, void* userdata);

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -190,25 +190,21 @@ void rtp_encoder_init(RtpEncoder* rtp_encoder, MediaCodec codec, RtpOnPacket on_
     case CODEC_H264:
       rtp_encoder->type = PT_H264;
       rtp_encoder->ssrc = SSRC_H264;
-      rtp_encoder->timestamp_increment = 90000 / 30;  // 30 FPS.
       rtp_encoder->encode_func = rtp_encoder_encode_h264;
       break;
     case CODEC_PCMA:
       rtp_encoder->type = PT_PCMA;
       rtp_encoder->ssrc = SSRC_PCMA;
-      rtp_encoder->timestamp_increment = CONFIG_AUDIO_DURATION * 8000 / 1000;
       rtp_encoder->encode_func = rtp_encoder_encode_generic;
       break;
     case CODEC_PCMU:
       rtp_encoder->type = PT_PCMU;
       rtp_encoder->ssrc = SSRC_PCMU;
-      rtp_encoder->timestamp_increment = CONFIG_AUDIO_DURATION * 8000 / 1000;
       rtp_encoder->encode_func = rtp_encoder_encode_generic;
       break;
     case CODEC_OPUS:
       rtp_encoder->type = PT_OPUS;
       rtp_encoder->ssrc = SSRC_OPUS;
-      rtp_encoder->timestamp_increment = CONFIG_AUDIO_DURATION * 48000 / 1000;
       rtp_encoder->encode_func = rtp_encoder_encode_generic;
       break;
     default:


### PR DESCRIPTION
Add two fields in `PeerConfiguration` structure. Users can configure video fps and audio duration when creating a `PeerConnection` instance. They can also leave these two fields zero to use the default value.