### PR TITLE
Fix macOS RTP endian macro mapping

### DIFF
--- a/src/rtp.h
+++ b/src/rtp.h
@@ -8,6 +8,9 @@
 #define __LITTLE_ENDIAN 1234
 #elif __APPLE__
 #include <machine/endian.h>
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
## Summary

- map the endian macros exported by `<machine/endian.h>` to the underscored identifiers used by libpeer's RTP bit-field selector
- keep the current RTP layout and all non-Apple preprocessing unchanged
- provide a minimal alternative to the broader explicit serialization change in #267

## Root cause

On macOS, `BYTE_ORDER`, `BIG_ENDIAN`, and `LITTLE_ENDIAN` are defined, but `__BYTE_ORDER`, `__BIG_ENDIAN`, and `__LITTLE_ENDIAN` are not. Undefined identifiers in the RTP `#if` expression evaluate as zero, so the big-endian bit-field layout is selected and an Opus RTP v2/PT111 header starts with `02 de` instead of `80 6f`.

## Validation

- compiled `src/rtp.c` with a strict (`-Wall -Wextra -Werror`) RTP wire regression on AppleClang
- confirmed the regression fails on upstream `main` at the expected first-byte assertion and passes with this change
- attempted the full CMake build; local dependency builds are blocked independently by obsolete cJSON/usrsctp CMake policies and existing mbedTLS documentation warnings promoted to errors by the current AppleClang

Fixes #268
