### PR TITLE
sctp: fix outgoing SACK corruption on DATA chunk reception

### DIFF
--- a/src/sctp.c
+++ b/src/sctp.c
@@ -273,8 +273,24 @@ void sctp_incoming_data(Sctp* sctp, char* buf, size_t len) {
           length += ntohs(data_chunk->length);
         } else if (ntohl(data_chunk->ppid) == DATA_CHANNEL_PPID_DOMSTRING || ntohl(data_chunk->ppid) == DATA_CHANNEL_PPID_BINARY) {
           if (sctp->onmessage) {
+            /*
+             * In case the "onmessage" callback sends a DATA chunk, we
+             * send the SACK first, and stop the processing after the
+             * callback.
+             */
+            out_packet->header.source_port = htons(sctp->local_port);
+            out_packet->header.destination_port = htons(sctp->remote_port);
+            out_packet->header.verification_tag = sctp->verification_tag;
+            out_packet->header.checksum = 0x00;
+            if (length > 0) {
+              // padding 4
+              length = (4 * ((length + 3) / 4));
+              out_packet->header.checksum = sctp_get_checksum(sctp, sctp->buf, length);
+              dtls_srtp_write(sctp->dtls_srtp, sctp->buf, length);
+            }
             sctp->onmessage((char*)data_chunk->data, ntohs(data_chunk->length) - sizeof(SctpDataChunk),
                             sctp->userdata, ntohs(data_chunk->sid));
+            return;
           }
         }
         pos = len;  // Do not handle other msg


### PR DESCRIPTION
On libpeer's own SCTP implementation, reception of a DATA chunk may result in a call to the `onmessage` callback, if available. Before running the callback, sctp_incoming_data() prepares a SACK chunk that is meant to be sent after the callback is done, but if the callback [sends any data as a response](https://github.com/sepfy/libpeer/blob/9319aa434cb9e893faed0293ba9d2a21eca59c8b/examples/pico/main.c#L37), it'll overwrite the already formatted SACK chunk header, corrupting the SACK.

Fix it by moving the SACK send before the callback.

**NOTE**: similar problems may surface depending on what the `onmessage`, `onopen` and `onclose` do. I've only seen this happening in the `SCTP_DATA` case but I think it could also happen in the `SCTP_COOKIE_ECHO` case. I haven't tested it, though, so any opinion is appreciated.

## Example

Before the fix, if the peer receives a DATA chunk, it first sends another DATA chunk as a response (similar to what https://github.com/sepfy/libpeer/blob/9319aa434cb9e893faed0293ba9d2a21eca59c8b/examples/pico/main.c#L34 does). Then, it sends the SACK chunk, whose buffer has been overwritten by the previous DATA send:

<img width="1186" height="473" alt="libpeer_sctp_malformed_sack_1" src="https://github.com/user-attachments/assets/60cee638-dc81-4f90-8bb3-1705bf146d66" />
<img width="1186" height="473" alt="libpeer_sctp_malformed_sack_2" src="https://github.com/user-attachments/assets/23372312-e42f-443e-90e0-f0ab4943abb4" />
<img width="1186" height="473" alt="libpeer_sctp_malformed_sack_3" src="https://github.com/user-attachments/assets/838b7e29-acf3-4b38-9eb7-b874baafbdf5" />

After the fix, on the same interchange, the peer sends the SACK first, then runs the `onmessage` callback to send the DATA chunk:

<img width="1186" height="473" alt="libpeer_sctp_malformed_sack_fix_1" src="https://github.com/user-attachments/assets/41a6c93c-26a0-4477-aad8-2bf7ed97c502" />
<img width="1186" height="473" alt="libpeer_sctp_malformed_sack_fix_2" src="https://github.com/user-attachments/assets/e18fd188-8448-478a-91de-d2ae55e6a6af" />
<img width="1186" height="473" alt="libpeer_sctp_malformed_sack_fix_3" src="https://github.com/user-attachments/assets/89d5c1a9-998e-4676-988d-eb95a1ae00db" />
